### PR TITLE
kill worker should also kill master

### DIFF
--- a/grma/mayue.py
+++ b/grma/mayue.py
@@ -28,7 +28,7 @@ class Mayue(object):
 
     def spawn_worker(self):
         sleep(0.1)
-        worker = Worker(self.app.server, self.app.args)
+        worker = Worker(self.pid, self.app.server, self.app.args)
 
         pid = os.fork()
 
@@ -80,16 +80,17 @@ class Mayue(object):
 
         print '-' * 28
 
-        print '[OK] Master running'
-        for i in range(self.app.args.num):
-            self.spawn_worker()
-
-        utils.setproctitle('grma master')
-
         if self.app.args.daemon:
             utils.daemonize()
 
         self.pid = os.getpid()
+
+        print '[OK] Master running pid: {pid}'.format(pid=self.pid)
+        utils.setproctitle('grma master pid={pid}'.format(pid=self.pid))
+
+        for i in range(self.app.args.num):
+            self.spawn_worker()
+
         if self.app.args.pid:
             self.pidfile = Pidfile(self.app.args.pid)
             self.pidfile.create(self.pid)
@@ -111,7 +112,7 @@ class Mayue(object):
         signal.signal(signal.SIGINT, self.handle_exit)
         signal.signal(signal.SIGQUIT, self.handle_exit)
         signal.signal(signal.SIGTERM, self.handle_exit)
-        signal.signal(signal.SIGCHLD, self.handle_exit)
+        signal.signal(signal.SIGCHLD, signal.SIG_IGN)
 
     def handle_exit(self, sig, frame):
         self.clean()

--- a/grma/worker.py
+++ b/grma/worker.py
@@ -4,9 +4,10 @@ import signal
 
 
 class Worker(object):
-    def __init__(self, server, args):
+    def __init__(self, pid, server, args):
         self.server = server
         self.args = args
+        self.master_pid = pid
         self.init_signals()
 
     def run(self):
@@ -25,9 +26,16 @@ class Worker(object):
 
     def _stop(self):
         self.stop()
+        self.kill_worker(self.master_pid, signal.SIGTERM)
 
     def handle_quit(self, sig, frame):
         self._stop()
 
     def handle_exit(self, sig, frame):
         self._stop()
+
+    def kill_worker(self, pid, sig):
+        try:
+            os.kill(pid, sig)
+        except OSError:
+            pass


### PR DESCRIPTION
1. parse master pid to worker object
2. kill worker try to kill master
3. daemonize master and save the pid (after daemonize) to worker

if daemonize a process, pid will be changed, and if we save into mem,
we cannot delete the right one.
