### PR TITLE
add better port check method

### DIFF
--- a/benchmark/server.py
+++ b/benchmark/server.py
@@ -24,7 +24,8 @@ class Server(ServerBase):
         self.started = False
 
     def bind(self, host, port, private_key_path='', certificate_chain_path=''):
-        self.server.add_insecure_port('%s:%s' % (host, port))
+        r = self.server.add_insecure_port('%s:%s' % (host, port))
+        return r
 
     def start(self):
         """start server"""

--- a/examples/server.py
+++ b/examples/server.py
@@ -16,7 +16,6 @@ class ServiceImpl(server_pb2.BetaSimpleServiceServicer):
 
 class Server(ServerBase):
     def __init__(self):
-        """Init a r2d2 server instance"""
         server = server_pb2.beta_create_SimpleService_server(
             ServiceImpl()
         )
@@ -24,7 +23,9 @@ class Server(ServerBase):
         self.started = False
 
     def bind(self, host, port, private_key_path='', certificate_chain_path=''):
-        self.server.add_insecure_port('%s:%s' % (host, port))
+        # return 0 if cannot binded
+        r = self.server.add_insecure_port('%s:%s' % (host, port))
+        return r
 
     def start(self):
         """start server"""

--- a/grma/app.py
+++ b/grma/app.py
@@ -72,6 +72,5 @@ class App(object):
 def run():
     Application().run()
 
-
 if __name__ == '__main__':
     run()

--- a/grma/utils.py
+++ b/grma/utils.py
@@ -52,16 +52,3 @@ def daemonize():
 
     os.dup2(fd_null, 1)
     os.dup2(fd_null, 2)
-
-
-def is_port_open(host, port):
-    # since grpc won't quit if port is in used,
-    # we have to check if port is open manually
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind((host, port))
-        return True
-    except OSError:
-        return False
-    finally:
-        s.close()


### PR DESCRIPTION
if we bind a gRPC host:port success, gRPC function should return port
value as return value, or return 0.

We could use this to check if bind status is OK.

@killpanda We need to change r2d2 as well.
